### PR TITLE
ARL configuration for online-cmaq

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -252,8 +252,8 @@ if [ "${APPLICATION}" = "ATMAQ" ]; then
   else  
     printf "... Checking out extra components for Online-CMAQ ...\n"
 
-#    printf "... Replace ufs-weather-model with a temporary fix ...\n"
-#    rm -rf "${SRW_DIR}/sorc/ufs-weather-model"
+    printf "... Replace ufs-weather-model ...\n"
+    rm -rf "${SRW_DIR}/sorc/ufs-weather-model"
 
     ./manage_externals/checkout_externals -e externals/Externals_AQM.cfg
 

--- a/externals/Externals_AQM.cfg
+++ b/externals/Externals_AQM.cfg
@@ -1,11 +1,11 @@
-#[ufs-weather-model]
-#protocol = git
-#repo_url = https://github.com/rmontuoro/ufs-weather-model
+[ufs-weather-model]
+protocol = git
+repo_url = https://github.com/noaa-oar-arl/ufs-weather-model
 # Specify either a branch name or a hash but not both.
-#branch = bugfix/aqm-heat-fluxes
+branch = develop
 #hash = 65cf401
-#local_path = sorc/ufs-weather-model
-#required = True
+local_path = sorc/ufs-weather-model
+required = True
 
 [arl_nexus]
 protocol = git

--- a/parm/aqm.rc
+++ b/parm/aqm.rc
@@ -29,11 +29,9 @@ ctm_pmdiag: true
 #
 #  Input emissions
 #
-{%- if do_aqm_canopy %}
-emission_sources: anthro fire canopy
-{%- else %}
 emission_sources: anthro fire
-{%- endif %}
+{%- if do_aqm_canopy %} canopy{% endif %}
+{%- if do_aqm_fengsha %} fengsha{% endif %}
 
 #
 #  Anthropogenic

--- a/ush/sample_config/ARL_run/config.yaml_cold_aqmna13km_1day_wcoss2
+++ b/ush/sample_config/ARL_run/config.yaml_cold_aqmna13km_1day_wcoss2
@@ -1,0 +1,84 @@
+metadata:
+  description: config for Online-CMAQ, AQM_NA_13km, cold start, 1cycle a day, on WCOSS2
+user:
+  RUN_ENVIR: community
+  MACHINE: wcoss2
+  ACCOUNT: AQM-DEV
+workflow:
+  USE_CRON_TO_RELAUNCH: true
+  CRON_RELAUNCH_INTVL_MNTS: 3
+  EXPT_BASEDIR: /lfs/h2/oar/ptmp/Patrick.C.Campbell/expt_dirs
+  EXPT_SUBDIR: aqm_cold_aqmna13_1day
+  CCPP_PHYS_SUITE: FV3_GFS_v15p2
+  DATE_FIRST_CYCL: '20190805'
+  DATE_LAST_CYCL: '20190805'
+  CYCL_HRS:
+    - 12
+  FCST_LEN_HRS: 6
+  PREEXISTING_DIR_METHOD: rename
+  VERBOSE: true
+  COMPILER: intel
+  DIAG_TABLE_TMPL_FN: diag_table_aqm
+  FIELD_TABLE_TMPL_FN: field_table_aqm
+nco:
+  NET: aqm
+workflow_switches:
+  RUN_TASK_MAKE_GRID: true
+  RUN_TASK_MAKE_OROG: true
+  RUN_TASK_MAKE_SFC_CLIMO: true
+  RUN_TASK_RUN_POST: true
+task_get_extrn_ics:
+  EXTRN_MDL_NAME_ICS: FV3GFS
+#  FV3GFS_FILE_FMT_ICS: grib2
+task_get_extrn_lbcs:
+  EXTRN_MDL_NAME_LBCS: FV3GFS
+  LBC_SPEC_INTVL_HRS: 6
+#  FV3GFS_FILE_FMT_LBCS: grib2
+task_run_fcst:
+  DT_ATMOS: 180
+  LAYOUT_X: 50
+  LAYOUT_Y: 34
+  BLOCKSIZE: 16
+  RESTART_INTERVAL: 12
+  WTIME_RUN_FCST: 02:00:00
+  QUILTING: true
+  PRINT_ESMF: false
+  PREDEF_GRID_NAME: AQM_NA_13km
+task_run_post:
+  POST_OUTPUT_DOMAIN_NAME: 793
+global:
+  DO_ENSEMBLE: false
+  NUM_ENS_MEMBERS: 2
+  HALO_BLEND: 0
+cpl_aqm_parm:
+  CPL_AQM: true
+  RUN_TASK_ADD_AQM_ICS: true
+  RUN_TASK_ADD_AQM_LBCS: true
+  RUN_TASK_RUN_NEXUS: true
+  NNODES_RUN_NEXUS: 4
+  PPN_RUN_NEXUS: 40
+  RUN_ADD_AQM_CHEM_LBCS: true
+  RUN_ADD_AQM_GEFS_LBCS: true
+  AQM_GEFS_CYC: 0
+  AQM_RC_TMPL_FN: aqm.rc
+  AQM_CONFIG_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/aqm/epa/data
+  AQM_BIO_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/aqm/bio
+  AQM_BIO_FILE: BEIS_RRFScmaq_C775.ncf
+  AQM_FENGSHA_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/FENGSHA
+  AQM_FENGSHA_FILE_PREFIX: FENGSHA_p8_10km_inputs
+  AQM_FENGSHA_FILE_SUFFIX: .nc  
+  AQM_CANOPY_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/canopy
+  AQM_CANOPY_FILE: gfs.t12z.geo
+  AQM_CANOPY_FILE_SUFFIX: .canopy_regrid.nc
+  AQM_FIRE_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/emissions/GSCE/RAVE.in.793/RAVE_RT
+  AQM_FIRE_FILE: Hourly_Emissions_regrid_NA_13km
+  AQM_FIRE_FILE_SUFFIX: _h72.nc
+  AQM_RC_FIRE_FREQUENCY: hourly
+  AQM_LBCS_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/LBCS/RRFS_NA13km_GEOS5_v2
+  AQM_LBCS_FILES: geos5_bndy_v2.c793.2013<MM>.nc
+  AQM_GEFS_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/GEFS_aerosol
+  NEXUS_INPUT_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/nexus_emissions
+  NEXUS_FIX_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/nexus/fix
+  NEXUS_GRID_FN: grid_spec_793.nc
+#  COLDSTART: false
+#  WARMSTART_CYCLE_DIR: /lfs/h2/emc/lam/noscrub/RRFS_CMAQ/restart/RRFS_CONUS_13km/2019080612


### PR DESCRIPTION
Automatically use the develop branch of our fork of ufs-weather-model (for ATMAQ)