### PR TITLE
Initial commit of new build scripts for GMU Hopper.

### DIFF
--- a/devbuild.sh
+++ b/devbuild.sh
@@ -10,7 +10,7 @@ OPTIONS
       show this help guide
   -p, --platform=PLATFORM
       name of machine you are building on
-      (e.g. cheyenne | hera | jet | orion | wcoss2)
+      (e.g. cheyenne | hera | jet | orion | wcoss2 | hopper)
   -c, --compiler=COMPILER
       compiler to use; default depends on platform
       (e.g. intel | gnu | cray | gccgfortran)
@@ -217,11 +217,12 @@ if [ "${DEFAULT_BUILD}" = true ]; then
   BUILD_UPP="on"
 fi
 
-# Choose components to build for air quality modeling (Online-CMAQ)
+# Choose components to build for Online-CMAQ
 if [ "${APPLICATION}" = "ATMAQ" ]; then
   if [ "${DEFAULT_BUILD}" = true ]; then
     BUILD_NEXUS="on"
     BUILD_AQM_UTILS="on"
+    BUILD_UPP="off"
   fi
   if [ "${PLATFORM}" = "wcoss2" ]; then
     BUILD_POST_STAT="on"
@@ -241,6 +242,7 @@ if [ -z "${COMPILER}" ] ; then
     cheyenne) COMPILER=intel ;;
     macos,singularity) COMPILER=gnu ;;
     odin,noaacloud) COMPILER=intel ;;
+    hopper) COMPILER=gnu ;;
     *)
       COMPILER=intel
       printf "WARNING: Setting default COMPILER=intel for new platform ${PLATFORM}\n" >&2;
@@ -322,7 +324,6 @@ CMAKE_SETTINGS="\
  -DBUILD_UFS_UTILS=${BUILD_UFS_UTILS}\
  -DBUILD_UPP=${BUILD_UPP}\
  -DBUILD_GSI=${BUILD_GSI}\
- -DBUILD_RRFS_UTILS=${BUILD_RRFS_UTILS}\
  -DBUILD_NEXUS=${BUILD_NEXUS}\
  -DBUILD_AQM_UTILS=${BUILD_AQM_UTILS}"
 
@@ -369,7 +370,7 @@ if [ "${VERBOSE}" = true ]; then
 fi
 
 # Before we go on load modules, we first need to activate Lmod for some systems
-source ${SRW_DIR}/etc/lmod-setup.sh $MACHINE
+#S.S# source ${SRW_DIR}/etc/lmod-setup.sh $MACHINE
 
 # source the module file for this platform/compiler combination, then build the code
 printf "... Load MODULE_FILE and create BUILD directory ...\n"

--- a/etc/lmod-setup.csh
+++ b/etc/lmod-setup.csh
@@ -6,7 +6,7 @@ Usage: source etc/lmod-setup.csh PLATFORM
 
 OPTIONS:
    PLATFORM - name of machine you are building on
-      (e.g. cheyenne | hera | jet | orion | wcoss2 )
+      (e.g. cheyenne | hera | jet | orion | wcoss2 | hopper)
 EOF_USAGE
    exit 1
 else
@@ -52,6 +52,10 @@ else if ( "$L_MACHINE" == odin ) then
    setenv LMOD_SYSTEM_DEFAULT_MODULES "PrgEnv-intel:cray-mpich:intel:craype"
    module --initial_load --no_redirect restore
    setenv MODULEPATH "/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
+
+else if ( "$L_MACHINE" == hopper ) then
+   setenv ENV "/usr/share/lmod/lmod/init/csh"
+   source $ENV
 
 else
    module purge

--- a/etc/lmod-setup.sh
+++ b/etc/lmod-setup.sh
@@ -7,7 +7,7 @@ Usage: source etc/lmod-setup.sh PLATFORM
 
 OPTIONS:
    PLATFORM - name of machine you are building on
-      (e.g. cheyenne | hera | jet | orion | wcoss2 )
+      (e.g. cheyenne | hera | jet | orion | wcoss2 | hopper)
 EOF_USAGE
    exit 1
 else
@@ -43,8 +43,11 @@ elif [ "$L_MACHINE" = singularity ]; then
    module purge
 
 elif [ "$L_MACHINE" = gaea ]; then
-   source /lustre/f2/dev/role.epic/contrib/Lmod_init.sh
+   export BASH_ENV="/lustre/f2/dev/role.epic/contrib/apps/lmod/lmod/init/bash"
+   source $BASH_ENV
 
+   export LMOD_SYSTEM_DEFAULT_MODULES="modules/3.2.11.4"
+   module --initial_load --no_redirect restore
 elif [ "$L_MACHINE" = odin ]; then
    module unload modules
    unset -f module
@@ -55,6 +58,10 @@ elif [ "$L_MACHINE" = odin ]; then
    export LMOD_SYSTEM_DEFAULT_MODULES="PrgEnv-intel:cray-mpich:intel:craype"
    module --initial_load --no_redirect restore
    export MODULEPATH="/oldscratch/ywang/external/hpc-stack/modulefiles/mpi/intel/2020/cray-mpich/7.7.16:/oldscratch/ywang/external/hpc-stack/modulefiles/compiler/intel/2020:/oldscratch/ywang/external/hpc-stack/modulefiles/core:/oldscratch/ywang/external/hpc-stack/modulefiles/stack:/opt/cray/pe/perftools/21.02.0/modulefiles:/opt/cray/ari/modulefiles:/opt/cray/pe/craype-targets/default/modulefiles:/opt/cray/pe/modulefiles:/opt/cray/modulefiles:/opt/modulefiles"
+
+elif [ "$L_MACHINE" = hopper ]; then
+   export BASH_ENV="/opt/ohpc/admin/lmod/lmod/init/bash"
+   source $BASH_ENV
 
 else
    module purge

--- a/modulefiles/build_hopper_gnu.lua
+++ b/modulefiles/build_hopper_gnu.lua
@@ -1,0 +1,88 @@
+help([[
+This module loads libraries for building the UFS SRW App on
+the GMU ORC machine Hopper using GNU 10.3
+]])
+
+whatis([===[Loads libraries needed for building the UFS SRW App on Hopper using GNU 10.3 ]===])
+
+-- prepend_path("MODULEPATH","/contrib/sutils/modulefiles")
+-- load("sutils")
+
+-- This path should point to your HPCstack installation directory
+local HPCstack="/opt/sw/other/apps/hpc-stack/"
+
+-- Load HPC stack
+prepend_path("MODULEPATH", pathJoin(HPCstack, "modulefiles/stack"))
+
+-- load(pathJoin("cmake", os.getenv("cmake_ver") or "3.20.1"))
+-- load(pathJoin("cmake", os.getenv("cmake_ver") or "3.22.1-6o"))
+
+-- gnu_ver=os.getenv("gnu_ver") or "9.2.0"
+-- load(pathJoin("gnu", gnu_ver))
+
+-- prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/gnu-9.2/modulefiles/stack")
+
+ load(pathJoin("hpc-stack", os.getenv("hpc_ver") or "1.2.0"))
+-- load(pathJoin("hpc-gnu", os.getenv("hpc-gnu_ver") or "9.2"))
+-- load(pathJoin("hpc-mpich", os.getenv("hpc-mpich_ver") or "3.3.2"))
+-- load(pathJoin("hpc-mpich", os.getenv("hpc-mpich_ver") or "hpc-mpich"))
+-- load("srw_common")
+--
+--
+-- These are default modules from Hopper HPCstack installation directory
+-- ----------------- /opt/sw/other/apps/hpc-stack/builds/modulefiles/mpi/gnu/10.3.0-ya/openmpi/4.1.2-4a ---------------------
+--   fms/2021.03             mapl/2.7.3-esmf-8.3.0b09        nemsiogfs/2.5.3 (D)    upp/10.0.9   (D)
+--   fms/2022.04 (D)         ncio/1.0.0               (D)    netcdf/4.7.4    (D)    wrf_io/1.2.0
+--   hdf5/1.10.6 (D:ohpc)    nemsio/2.5.2             (D)    pio/2.5.3
+
+-- -------------------------- /opt/sw/other/apps/hpc-stack/builds/modulefiles/compiler/gnu/10.3.0-ya ---------------------------
+--   bacio/2.4.1  (D)    gfsio/1.4.1          (D)       ip2/1.1.2         (D)    netcdf/4.7.4           w3nco/2.4.1    (D)
+--   bufr/11.5.0         gftl-shared/v1.3.0   (D)       jasper/2.0.25     (D)    prod_util/1.2.2        wgrib2/2.0.8   (D)
+--   crtm/2.3.0   (D)    grib_util/1.2.2                jpeg/9.1.0               sfcio/1.4.1     (D)    yafyaml/v0.5.1 (D)
+--   g2/3.4.2     (D)    hdf5/1.10.6          (ohpc)    landsfcutil/2.4.1 (D)    sigio/2.3.2     (D)    zlib/1.2.11    (D)
+--   g2c/1.6.2           hpc-openmpi/4.1.2-4a           libpng/1.6.35     (D)    sp/2.3.3        (D)
+--   g2tmpl/1.9.1 (D)    ip/3.3.3             (D)       nccmp/1.8.9.0     (D)    w3emc/2.9.2     (D)
+
+
+load("jasper/2.0.25")
+load("zlib/1.2.11")
+load("libpng")
+
+load("netcdf/4.7.4")
+load("pio/2.5.3")
+-- load("esmf/8.3.0b09")
+
+load("fms/2022.04")
+
+load("bufr/11.5.0")
+load("bacio/2.4.1")
+load("crtm/2.3.0")
+load("g2/3.4.3")
+load("g2tmpl/1.9.1")
+load("ip/3.3.3")
+load("sp/2.3.3")
+load("w3emc/2.9.2")
+
+load("gftl-shared/v1.3.0")
+load("yafyaml/v0.5.1")
+load("mapl/2.7.3-esmf-8.3.0b09")
+
+load("nemsio/2.5.2")
+load("sfcio/1.4.1")
+load("sigio/2.3.2")
+load("w3nco/2.4.1")
+load("wrf_io/1.2.0")
+
+load("ncio/1.0.0")
+load("wgrib2/2.0.8")
+
+load("nco")
+load("nccmp")
+
+-- load(pathJoin("nccmp", os.getenv("nccmp_ver") or "1.8.9"))
+-- load(pathJoin("nco", os.getenv("nco_ver") or "4.9.3"))
+
+setenv("CMAKE_C_COMPILER","mpicc")
+setenv("CMAKE_CXX_COMPILER","mpicxx")
+setenv("CMAKE_Fortran_COMPILER","mpif90")
+setenv("CMAKE_Platform","hera.gnu")

--- a/ush/valid_param_vals.yaml
+++ b/ush/valid_param_vals.yaml
@@ -4,7 +4,7 @@
 valid_vals_RUN_ENVIR: ["nco", "community"]
 valid_vals_VERBOSE: [True, False]
 valid_vals_DEBUG: [True, False]
-valid_vals_MACHINE: ["HERA", "WCOSS2", "ORION", "JET", "ODIN", "CHEYENNE", "STAMPEDE", "LINUX", "MACOS", "NOAACLOUD", "SINGULARITY", "GAEA"]
+valid_vals_MACHINE: ["HERA", "WCOSS2", "ORION", "JET", "ODIN", "CHEYENNE", "STAMPEDE", "LINUX", "MACOS", "NOAACLOUD", "SINGULARITY", "GAEA", "HOPPER"]
 valid_vals_SCHED: ["slurm", "pbspro", "lsf", "lsfcray", "none"]
 valid_vals_FCST_MODEL: ["ufs-weather-model"]
 valid_vals_WORKFLOW_MANAGER: ["rocoto", "none"]


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

This is a PR for the initial commit of working build scripts needed to build the UFS-SRW-App ATMAQ model on the GMU Hopper system.  the GMU Hopper system uses GNU compilers.   In order to test build the system on Hopper, please first invoke:
```
module reset
module load hpc-stack
```
This makes all necessary hpc-stack modules available for loading in the new  ```modulefiles/build_hopper_gnu.lua``` file.  

I have also added default Hopper build files for the necessary components including [UFS-Weather-Model](https://github.com/noaa-oar-arl/ufs-weather-model/commit/a3cff561d1b3653c8ef44beaf37fdb0735c3964d), [AQM-utils](https://github.com/noaa-oar-arl/AQM-utils/commit/efd6b139a4a320f0283fc88d48cc3623cc6fa5ae), and [UFS_Utils](https://github.com/noaa-oar-arl/UFS_UTILS/commit/ab5bb34b4746a9fbc3ad739b6e7a60518bbdcfee).  These exist in our forked noaa-oar-arl [develop] branches, and so those should be used in Externals.cfg if compiling on Hopper.  These are not necessarily used since all hpc-stack modules are loaded up front in the ```modulefiles/build_hopper_gnu.lua``` , but they are required in the devbuild.sh script starting on [line 344](https://github.com/noaa-oar-arl/ufs-srweather-app/blob/develop/devbuild.sh#L344).  I did not want to remove these from the devbuild.sh script, so if using authoritative repositories' hashes for these components instead, I suppose these [lines](https://github.com/noaa-oar-arl/ufs-srweather-app/blob/develop/devbuild.sh#L344-L362) could be commented out from devbuild.sh.

On a side note, GMU ORC Support is currently installing Rocoto for the workflow so we can do some testing on generating and running a workflow here soon.  Updates to the necessary workflow module files will be addressed in a separate PR.  

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [ ] hera.intel
- [ ] orion.intel
- [ ] cheyenne.intel
- [ ] cheyenne.gnu
- [ ] gaea.intel
- [ ] jet.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)
- [X] hopper.gnu (new system)

## DEPENDENCIES:
<!-- Add any links to external PRs (e.g. regional_workflow and/or UFS PRs). For example:
- ufs-community/regional_workflow/pull/<pr_number>
- ufs-community/UFS_UTILS/pull/<pr_number>
- ufs-community/ufs-weather-model/pull/<pr_number> -->
- 

## DOCUMENTATION:
<!-- If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files (docs/UsersGuide/source) as supporting material. -->
N/A (work in progress)

## ISSUE: 
<!-- If this PR is resolving or referencing one or more issues, in this repository or elsewhere, list them here (Remember, issues must always be created before starting work on a PR branch!). For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/ufs-community/other_repository/pull/63" -->

N/A

## CHECKLIST
<!-- Add an X to check off a box. -->
- [X] My code follows the style guidelines in the Contributor's Guide
- [ ] I have performed a self-review of my own code using the Code Reviewer's Guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X ] My changes do not require updates to the documentation (explain).
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published

## LABELS (optional): 
<!-- If you do not have permissions to add labels to your own PR, request that labels be added here. 
Add an X to check off a box. Delete any unnecessary labels. -->
A Code Manager needs to add the following labels to this PR: 
- [X ] Work In Progress
- [ ] bug
- [X ] enhancement
- [ ] documentation
- [ ] release
- [ ] high priority
- [ ] run_ci
- [ ] run_we2e_fundamental_tests
- [ ] run_we2e_comprehensive_tests
- [ ] Needs Cheyenne test 
- [ ] Needs Jet test 
- [ ] Needs Hera test 
- [ ] Needs Orion test 
- [ ] help wanted

## CONTRIBUTORS (optional): 
<!-- If others have contributed to this work aside from the PR author, list them here -->
GMU ORC Support
