### PR TITLE
feat: support gaeac6 using default AQM config

### DIFF
--- a/doc/UsersGuide/BuildingRunningTesting/AQM.rst
+++ b/doc/UsersGuide/BuildingRunningTesting/AQM.rst
@@ -21,7 +21,7 @@ Quick Start Guide (SRW-AQM)
 
 .. attention::
 
-   These instructions should work smoothly on Hera, Hercules, Derecho and Orion but users on other systems may need to make additional adjustments. 
+   These instructions should work smoothly on Hera, Hercules, Derecho, Orion, and Gaea-C6 but users on other systems may need to make additional adjustments.
 
 Download the Code
 -------------------
@@ -46,7 +46,7 @@ On Hera and WCOSS2, users can build the SRW App AQM binaries with the following 
 
    ./devbuild.sh -p=<machine> -a=ATMAQ
 
-where ``<machine>`` is ``hera``, ``hercules``, ``orion``, or ``derecho``. The ``-a`` argument indicates the configuration/version of the application to build. 
+where ``<machine>`` is ``hera``, ``hercules``, ``orion``, ``derecho``, and ``gaeac6``. The ``-a`` argument indicates the configuration/version of the application to build.
 
 Building the SRW App with AQM on other machines, including other :srw-wiki:`Level 1 <Supported-Platforms-and-Compilers>` platforms, is not currently guaranteed to work, and users may have to make adjustments to the modulefiles for their system. 
 
@@ -78,7 +78,7 @@ Load the python environment for the workflow:
    module use /path/to/ufs-srweather-app/modulefiles
    module load wflow_<machine>
 
-where ``<machine>`` is ``hera``, ``hercules``, ``orion``, or ``derecho``. The workflow should load on other platforms listed under the ``MACHINE`` variable in :numref:`Section %s <user>`, but users may need to adjust other elements of the process when running on those platforms. 
+where ``<machine>`` is ``hera``, ``hercules``, ``orion``, ``derecho``, or ``gaeac6``. The workflow should load on other platforms listed under the ``MACHINE`` variable in :numref:`Section %s <user>`, but users may need to adjust other elements of the process when running on those platforms.
 
 If the console outputs a message, the user should run the commands specified in the message. For example, if the output says: 
 
@@ -104,6 +104,9 @@ Users will need to configure their experiment by setting parameters in the ``con
 Users will need to change the ``MACHINE`` and ``ACCOUNT`` variables in ``config.yaml`` to match their system. They may also wish to adjust other experiment settings. For more information on each task and variable, see :numref:`Section %s <ConfigWorkflow>`. 
 
 The community AQM configuration assumes that users have :term:`HPSS` access and attempts to download the data from HPSS. However, if users have the data on their system already, they may prefer to add the following lines to ``task_get_extrn_*:`` in their ``config.yaml`` file, adjusting the file path to point to the correct data locations:
+
+.. attention::
+    HPSS is not available on ``gaeac6``. User-staged data must be used.
 
 .. code-block:: console
 
@@ -311,5 +314,4 @@ Run the WE2E test:
 
 .. code-block:: console
 
-   $ ./run_WE2E_tests.py -t my_tests.txt -m hera -a gsd-fv3 -q
-
+   $ ./run_wE2E_tests.py -t my_tests.txt -m hera -a gsd-fv3 -q

--- a/modulefiles/tasks/gaeac6/nexus_emission.local.lua
+++ b/modulefiles/tasks/gaeac6/nexus_emission.local.lua
@@ -1,2 +1,4 @@
 unload("python_srw")
 load("python_srw_aqm")
+
+setenv("FI_CXI_RX_MATCH_MODE", "hybrid")

--- a/ush/config.aqm.yaml
+++ b/ush/config.aqm.yaml
@@ -22,7 +22,8 @@ workflow:
   FIELD_TABLE_TMPL_FN: field_table_aqm.FV3_GFS_v16
   DO_REAL_TIME: false
   COLDSTART: false      # set to true for cold start
-  WARMSTART_CYCLE_DIR: '/scratch2/NAGAPE/epic/SRW-AQM_DATA/aqm_data/restart/2023111000' # for hera
+  WARMSTART_CYCLE_DIR: /gpfs/f6/bil-fire3/scratch/Wei.K.Li/aqm_data/restart/2023111000 # for gaeac6
+#  WARMSTART_CYCLE_DIR: '/scratch2/NAGAPE/epic/SRW-AQM_DATA/aqm_data/restart/2023111000' # for hera
 #  WARMSTART_CYCLE_DIR: '/work/noaa/epic/SRW-AQM_DATA/aqm_data/restart/2023111000' # for orion/hercules
 #  WARMSTART_CYCLE_DIR: '/glade/work/chanhooj/SRW-AQM_DATA/aqm_data/restart/2023111000' # for derecho
   taskgroups:
@@ -34,9 +35,6 @@ nco:
   envir_default: test_aqm_warmstart
   NET_default: aqm
   RUN_default: aqm
-#rocoto: # uncomment this section in case of COLDSTART: true
-#  tasks:
-#    task_aqm_ics_ext: !remove
 task_get_extrn_ics:
   envvars:
     EXTRN_MDL_NAME_ICS: FV3GFS
@@ -48,6 +46,11 @@ task_get_extrn_lbcs:
     LBC_SPEC_INTVL_HRS: 6
     FV3GFS_FILE_FMT_LBCS: netcdf
     EXTRN_MDL_LBCS_OFFSET_HRS: 0
+task_nexus_emission:
+  envvars:
+    PPN_NEXUS_EMISSION: 20
+    NNODES_NEXUS_EMISSION: 4
+    OMP_NUM_THREADS_NEXUS_EMISSION: 2
 task_run_fcst:
   fv3:
     execution:
@@ -59,9 +62,6 @@ task_run_fcst:
     PRINT_ESMF: false
     RESTART_INTERVAL: 12 24
     DO_FCST_RESTART: false
-  LAYOUT_X: 50
-  LAYOUT_Y: 34
-  BLOCKSIZE: 16
   QUILTING: true
 task_run_post:
   envvars:
@@ -90,5 +90,6 @@ cpl_aqm_parm:
   AQM_RC_FIRE_FREQUENCY: hourly
   AQM_LBCS_FILES: am4_bndy.c793.2019<MM>.v1.nc
   AQM_GEFS_FILE_PREFIX: geaer
+  AQM_GEFS_FILE_CYC: '00'
   NEXUS_GRID_FN: grid_spec_793.nc
   NUM_SPLIT_NEXUS: 3

--- a/ush/config.aqm.yaml
+++ b/ush/config.aqm.yaml
@@ -22,7 +22,7 @@ workflow:
   FIELD_TABLE_TMPL_FN: field_table_aqm.FV3_GFS_v16
   DO_REAL_TIME: false
   COLDSTART: false      # set to true for cold start
-  WARMSTART_CYCLE_DIR: /gpfs/f6/bil-fire3/scratch/Wei.K.Li/aqm_data/restart/2023111000 # for gaeac6
+  WARMSTART_CYCLE_DIR: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/aqm_data/restart/2023111000 # for gaeac6
 #  WARMSTART_CYCLE_DIR: '/scratch2/NAGAPE/epic/SRW-AQM_DATA/aqm_data/restart/2023111000' # for hera
 #  WARMSTART_CYCLE_DIR: '/work/noaa/epic/SRW-AQM_DATA/aqm_data/restart/2023111000' # for orion/hercules
 #  WARMSTART_CYCLE_DIR: '/glade/work/chanhooj/SRW-AQM_DATA/aqm_data/restart/2023111000' # for derecho

--- a/ush/config_defaults.yaml
+++ b/ush/config_defaults.yaml
@@ -2858,7 +2858,7 @@ cpl_aqm_parm:
   DO_AQM_SAVE_AIRNOW_HIST: false
   DO_AQM_SAVE_FIRE: false
 
-  COMINairnow_default: "/path/to/airnow/obaservation/data"
+  COMINairnow_default: "/path/to/airnow/observation/data"
   COMINfire_default: ""
   COMINgefs_default: ""
 

--- a/ush/machine/gaeac6.yaml
+++ b/ush/machine/gaeac6.yaml
@@ -59,6 +59,11 @@ data:
     RAP: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/input_model_data/RAP/${yyyymmdd}${hh}
     GSMGFS: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/input_model_data/GSMGFS/${yyyymmdd}${hh}
 
+cpl_aqm_parm:
+  COMINfire_default: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/aqm_data/RAVE_fire
+  COMINgefs_default: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/aqm_data/GEFS_DATA
+  NEXUS_GFS_SFC_DIR: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/aqm_data/GFS_SFC_DATA
+
 smoke_dust_parm:
   COMINsmoke_default: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/data_smoke_dust/RAVE_smoke_dust
   COMINrave_default: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/data_smoke_dust/RAVE_fire

--- a/ush/machine/gaeac6.yaml
+++ b/ush/machine/gaeac6.yaml
@@ -43,7 +43,6 @@ platform:
   FIXemis: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_emis
   # Uncomment these paths (and comment the corresponding above) when working with an AQMv8-enabled UFS-WM
 #  FIXaqm: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/SRW-AQM-v8/fix/fix_aqm
-#  FIXemis: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/SRW-AQM-v8/fix/fix_emis
   FIXsmoke: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_smoke
   FIXupp: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_upp
   FIXcrtm: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_crtm

--- a/ush/machine/gaeac6.yaml
+++ b/ush/machine/gaeac6.yaml
@@ -39,8 +39,11 @@ platform:
   FIXorg: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_orog
   FIXsfc: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_sfc_climo
   FIXshp: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/NaturalEarth
-  FIXaqm: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/SRW-AQM-v8/fix/fix_aqm
-  FIXemis: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/SRW-AQM-v8/fix/fix_emis
+  FIXaqm: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_aqm
+  FIXemis: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_emis
+  # Uncomment these paths (and comment the corresponding above) when working with an AQMv8-enabled UFS-WM
+#  FIXaqm: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/SRW-AQM-v8/fix/fix_aqm
+#  FIXemis: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/SRW-AQM-v8/fix/fix_emis
   FIXsmoke: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_smoke
   FIXupp: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_upp
   FIXcrtm: /gpfs/f6/bil-fire8/world-shared/UFS_SRW_data/develop/fix/fix_crtm


### PR DESCRIPTION
* Adds support for Gaea-C6 using the default AQM config.
* After chatting with @MichaelLueken, we need to keep the AQMv7 files as the default in `develop` until we actually pull in the AQMv8 UFS-WM hash (otherwise the e2e test fails). When that upgrade begins, we can maintain a feature branch where these v8 paths become the default.